### PR TITLE
Update readme files with compatible ballerina versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ following operations are supported.
 * TTL
 * TYPE
 
+## Compatibility
+
+|                             |           Version           |
+|:---------------------------:|:---------------------------:|
+| Ballerina Language          |            1.1.2            |
+
 ```ballerina
 import wso2/redis;
 import ballerina/io;

--- a/redis/src/redis/Module.md
+++ b/redis/src/redis/Module.md
@@ -15,6 +15,12 @@ below.
 
 Once the client is created, redis commands can be executed through that client.
 
+## Compatibility
+
+|                             |           Version           |
+|:---------------------------:|:---------------------------:|
+| Ballerina Language          |            1.1.2            |
+
 ## Samples
 
 ### Creating a Client


### PR DESCRIPTION
## Purpose
> Need to display the module's compatible ballerina versions in ballerina central

## Goals
> Make the module ready to be pushed into ballerina central.

## Approach
- Update compatible ballerina versions tables in Readme files.

## Test environment
> latest ballerina version (1.1.2)
